### PR TITLE
#13 - db settings not docker but ec2 local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,macos,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=java,gradle,intellij+all,windows,macos,visualstudiocode
 
+# MySQL
+/mysql8/*
+
 # QueryDSL
 /src/main/generated
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,21 @@ services:
       - 8080:8080
     environment:
       TZ: "Asia/Seoul"
+
+#  brick-db:
+#    platform: linux/x86_64
+#    image: mysql:8.0.17
+#    container_name: brick-db
+#    restart: always
+#    ports:
+#      - 3306:3306
+#    environment:
+#      MYSQL_ROOT_PASSWORD: root
+#      TZ: Asia/Seoul
+#    command:
+#      - --character-set-server=utf8mb4
+#      - --collation-server=utf8mb4_unicode_ci
+#    volumes:
+#      - ./mysql8/db:/var/lib/mysql
+#      - ./mysql8/config:/etc/mysql
+#      - ./mysql8/mysql-files:/var/lib/mysql-files

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,8 @@ spring:
 
   datasource:
     url: jdbc:mysql://ec2-3-35-51-115.ap-northeast-2.compute.amazonaws.com:3306/dev_brick_db
-    username: root
-    password: root
+    username: imimtu
+    password: Imimtu12!
     driver-class-name: com.mysql.cj.jdbc.Driver # MySQL 8 용 드라이버
 
   # h2 설정용 임시 세팅


### PR DESCRIPTION
decided not to use mysql8 through docker.
- our auto-deploy(github-action) works through docker-compose and it turn-off the container if deploy fails
- decided not to use docker during development