### PR TITLE
fix: change docker volume type to bind mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,9 @@ services:
     container_name: brick-server
     image: lsyeup1206/brick-server
     volumes:
-      - /home/logs/brick-server-log:./log
+      - type: bind
+        source: ./log
+        target: /home/logs/brick-server-log
     expose:
       - 8080
     ports:


### PR DESCRIPTION
changed docker volume type to bind. target path of our logfiles is `/home/logs/brick-server-log`